### PR TITLE
Support templatized `CFBundleShortVersionString`

### DIFF
--- a/jeroboam
+++ b/jeroboam
@@ -118,6 +118,7 @@ class App
     return true if sparkle_version.nil?
     @is_sparkle_outdated ||= begin
       parseable_version, _ = sparkle_version.split(' ')
+      parseable_version.gsub!('##VERSION##', version) if parseable_version =~ /##VERSION##/
       Gem::Version.new(parseable_version) < SPARKLE_MIN_VERSION
     end
   end


### PR DESCRIPTION
from Info.plist instead of hard-coded. There was this app that did this, and it looks like Sparkle (or a fork of it) understands what to do. Without this patch, the script explodes and doesn't process any versions. It probably should rescue and inform the user of version parse failure too as a future enhancement for somebody else.